### PR TITLE
Fix server error when joining a game with no maps

### DIFF
--- a/app/controllers/game_sessions_controller.rb
+++ b/app/controllers/game_sessions_controller.rb
@@ -9,6 +9,7 @@ class GameSessionsController < ApplicationController
   end
   
   def show
+    return redirect_back(fallback_location: root_url) if @game.blank? || @game.maps.blank?
     @map = @game.maps.first
     @active_floor = @map.floors.first
   end


### PR DESCRIPTION
What I did:
- start with an empty database
- create a gm user
- share the link shown when logging in
- join the session as a guest user

What I expected: 
- a pretty much empty playing screen

What I got:
- Server error due to `@map` being empty